### PR TITLE
Fix Iron Golem Material and Standardize Syntax

### DIFF
--- a/animations/armor_stand.animation.json
+++ b/animations/armor_stand.animation.json
@@ -5,34 +5,34 @@
 			"loop": true,
 			"bones": {
 				"head": {
-					"rotation": ["(math.mod(math.floor(query.mark_variant / 10000), 100) + (math.mod(math.floor(query.mark_variant / 4000000), 2) * 100)) * (query.is_interested > 0 ? -1 : 1)",
-   "(math.mod(math.floor(query.mark_variant / 100), 100) + (math.mod(math.floor(query.mark_variant / 2000000), 2) * 100)) * (query.is_charged > 0 ? -1 : 1)",
-   "((math.mod(query.mark_variant, 100) + math.mod(math.floor(query.mark_variant / 1000000), 2) * 100)) * (query.is_powered > 0 ? -1 : 1)"]
+					"rotation": ["(math.mod(math.floor(q.mark_variant / 10000), 100) + (math.mod(math.floor(q.mark_variant / 4000000), 2) * 100)) * (q.is_interested > 0 ? -1 : 1)",
+   "(math.mod(math.floor(q.mark_variant / 100), 100) + (math.mod(math.floor(q.mark_variant / 2000000), 2) * 100)) * (q.is_charged > 0 ? -1 : 1)",
+   "((math.mod(q.mark_variant, 100) + math.mod(math.floor(q.mark_variant / 1000000), 2) * 100)) * (q.is_powered > 0 ? -1 : 1)"]
 				},
 				"geyser_chest": {
-					"rotation": ["(math.mod(math.floor(query.variant / 10000), 100) + (math.mod(math.floor(query.variant / 4000000), 2) * 100)) * (query.is_in_love > 0 ? -1 : 1)",
-   "(math.mod(math.floor(query.variant / 100), 100) + (math.mod(math.floor(query.variant / 2000000), 2) * 100)) * (query.is_celebrating > 0 ? -1 : 1)",
-   "((math.mod(query.variant, 100) + math.mod(math.floor(query.variant / 1000000), 2) * 100)) * (query.is_celebrating_special > 0 ? -1 : 1)"]
+					"rotation": ["(math.mod(math.floor(q.variant / 10000), 100) + (math.mod(math.floor(q.variant / 4000000), 2) * 100)) * (q.is_in_love > 0 ? -1 : 1)",
+   "(math.mod(math.floor(q.variant / 100), 100) + (math.mod(math.floor(q.variant / 2000000), 2) * 100)) * (q.is_celebrating > 0 ? -1 : 1)",
+   "((math.mod(q.variant, 100) + math.mod(math.floor(q.variant / 1000000), 2) * 100)) * (q.is_celebrating_special > 0 ? -1 : 1)"]
 				},
 				"leftarm": {
-					"rotation": ["(math.mod(math.floor(query.trade_tier / 10000), 100) + (math.mod(math.floor(query.trade_tier / 4000000), 2) * 100)) * (query.is_charging > 0 ? -1 : 1)",
-   "(math.mod(math.floor(query.trade_tier / 100), 100) + (math.mod(math.floor(query.trade_tier / 2000000), 2) * 100)) * (query.is_critical > 0 ? -1 : 1)",
-   "((math.mod(query.trade_tier, 100) + math.mod(math.floor(query.trade_tier / 1000000), 2) * 100)) * (query.is_dancing > 0 ? -1 : 1)"]
+					"rotation": ["(math.mod(math.floor(q.trade_tier / 10000), 100) + (math.mod(math.floor(q.trade_tier / 4000000), 2) * 100)) * (q.is_charging > 0 ? -1 : 1)",
+   "(math.mod(math.floor(q.trade_tier / 100), 100) + (math.mod(math.floor(q.trade_tier / 2000000), 2) * 100)) * (q.is_critical > 0 ? -1 : 1)",
+   "((math.mod(q.trade_tier, 100) + math.mod(math.floor(q.trade_tier / 1000000), 2) * 100)) * (q.is_dancing > 0 ? -1 : 1)"]
 				},
 				"rightarm": {
-					"rotation": ["(math.mod(math.floor(query.max_trade_tier / 10000), 100) + (math.mod(math.floor(query.max_trade_tier / 4000000), 2) * 100)) * (query.is_elder > 0 ? -1 : 1)",
-   "(math.mod(math.floor(query.max_trade_tier / 100), 100) + (math.mod(math.floor(query.max_trade_tier / 2000000), 2) * 100)) * (query.is_emoting > 0 ? -1 : 1)",
-   "((math.mod(query.max_trade_tier, 100) + math.mod(math.floor(query.max_trade_tier / 1000000), 2) * 100)) * (query.is_idling > 0 ? -1 : 1)"]
+					"rotation": ["(math.mod(math.floor(q.max_trade_tier / 10000), 100) + (math.mod(math.floor(q.max_trade_tier / 4000000), 2) * 100)) * (q.is_elder > 0 ? -1 : 1)",
+   "(math.mod(math.floor(q.max_trade_tier / 100), 100) + (math.mod(math.floor(q.max_trade_tier / 2000000), 2) * 100)) * (q.is_emoting > 0 ? -1 : 1)",
+   "((math.mod(q.max_trade_tier, 100) + math.mod(math.floor(q.max_trade_tier / 1000000), 2) * 100)) * (q.is_idling > 0 ? -1 : 1)"]
 				},
 				"leftleg": {
-					"rotation": ["(math.mod(math.floor(query.skin_id / 10000), 100) + (math.mod(math.floor(query.skin_id / 4000000), 2) * 100)) * (query.is_illager_captain > 0 ? -1 : 1)",
-   "(math.mod(math.floor(query.skin_id / 100), 100) + (math.mod(math.floor(query.skin_id / 2000000), 2) * 100)) * (query.is_in_ui > 0 ? -1 : 1)",
-   "((math.mod(query.skin_id, 100) + math.mod(math.floor(query.skin_id / 1000000), 2) * 100)) * (query.is_lingering > 0 ? -1 : 1)"]
+					"rotation": ["(math.mod(math.floor(q.skin_id / 10000), 100) + (math.mod(math.floor(q.skin_id / 4000000), 2) * 100)) * (q.is_illager_captain > 0 ? -1 : 1)",
+   "(math.mod(math.floor(q.skin_id / 100), 100) + (math.mod(math.floor(q.skin_id / 2000000), 2) * 100)) * (q.is_in_ui > 0 ? -1 : 1)",
+   "((math.mod(q.skin_id, 100) + math.mod(math.floor(q.skin_id / 1000000), 2) * 100)) * (q.is_lingering > 0 ? -1 : 1)"]
 				},
 				"rightleg": {
-					"rotation": ["(math.mod(math.floor(query.hurt_direction / 10000), 100) + (math.mod(math.floor(query.hurt_direction / 4000000), 2) * 100)) * (query.is_pregnant > 0 ? -1 : 1)",
-   "(math.mod(math.floor(query.hurt_direction / 100), 100) + (math.mod(math.floor(query.hurt_direction / 2000000), 2) * 100)) * (query.is_sheared > 0 ? -1 : 1)",
-   "((math.mod(query.hurt_direction, 100) + math.mod(math.floor(query.hurt_direction / 1000000), 2) * 100)) * (query.is_stalking > 0 ? -1 : 1)"]
+					"rotation": ["(math.mod(math.floor(q.hurt_direction / 10000), 100) + (math.mod(math.floor(q.hurt_direction / 4000000), 2) * 100)) * (q.is_pregnant > 0 ? -1 : 1)",
+   "(math.mod(math.floor(q.hurt_direction / 100), 100) + (math.mod(math.floor(q.hurt_direction / 2000000), 2) * 100)) * (q.is_sheared > 0 ? -1 : 1)",
+   "((math.mod(q.hurt_direction, 100) + math.mod(math.floor(q.hurt_direction / 1000000), 2) * 100)) * (q.is_stalking > 0 ? -1 : 1)"]
 				}
 			}
 		}

--- a/attachables/diamond_chestplate.armor_stand.json
+++ b/attachables/diamond_chestplate.armor_stand.json
@@ -3,7 +3,7 @@
   "minecraft:attachable": {
     "description": {
       "identifier": "minecraft:diamond_chestplate.armor_stand",
-      "item": { "minecraft:diamond_chestplate": "query.owner_identifier == 'minecraft:armor_stand'" },
+      "item": { "minecraft:diamond_chestplate": "q.owner_identifier == 'minecraft:armor_stand'" },
       "materials": {
         "default": "armor",
         "enchanted": "armor_enchanted"
@@ -16,7 +16,7 @@
         "default": "geometry.armor_stand.armor.chestplate"
       },
       "scripts": {
-        "parent_setup": "variable.chest_layer_visible = 0.0;"
+        "parent_setup": "v.chest_layer_visible = 0.0;"
       },
       "render_controllers": [ "controller.render.armor" ]
     }

--- a/attachables/diamond_leggings.armor_stand.json
+++ b/attachables/diamond_leggings.armor_stand.json
@@ -3,7 +3,7 @@
   "minecraft:attachable": {
     "description": {
       "identifier": "minecraft:diamond_leggings.armor_stand",
-      "item": { "minecraft:diamond_leggings": "query.owner_identifier == 'minecraft:armor_stand'" },
+      "item": { "minecraft:diamond_leggings": "q.owner_identifier == 'minecraft:armor_stand'" },
       "materials": {
         "default": "armor",
         "enchanted": "armor_enchanted"
@@ -16,7 +16,7 @@
         "default": "geometry.armor_stand.armor.leggings"
       },
       "scripts": {
-        "parent_setup": "variable.leg_layer_visible = 0.0;"
+        "parent_setup": "v.leg_layer_visible = 0.0;"
       },
       "render_controllers": [ "controller.render.armor" ]
     }

--- a/attachables/elytra.armor_stand.json
+++ b/attachables/elytra.armor_stand.json
@@ -3,7 +3,7 @@
   "minecraft:attachable": {
     "description": {
       "identifier": "minecraft:elytra.armor_stand",
-      "item": { "minecraft:elytra": "query.owner_identifier == 'minecraft:armor_stand'" },
+      "item": { "minecraft:elytra": "q.owner_identifier == 'minecraft:armor_stand'" },
       "materials": {
         "default": "elytra",
         "enchanted": "elytra_glint"
@@ -24,7 +24,7 @@
         "swimming": "animation.elytra.swimming"
       },
       "scripts": {
-        "parent_setup": "variable.chest_layer_visible = 0.0;",
+        "parent_setup": "v.chest_layer_visible = 0.0;",
         "animate": [
           "default_controller"
         ]

--- a/attachables/golden_chestplate.armor_stand.json
+++ b/attachables/golden_chestplate.armor_stand.json
@@ -3,7 +3,7 @@
   "minecraft:attachable": {
     "description": {
       "identifier": "minecraft:golden_chestplate.armor_stand",
-      "item": { "minecraft:golden_chestplate": "query.owner_identifier == 'minecraft:armor_stand'" },
+      "item": { "minecraft:golden_chestplate": "q.owner_identifier == 'minecraft:armor_stand'" },
       "materials": {
         "default": "armor",
         "enchanted": "armor_enchanted"
@@ -16,7 +16,7 @@
         "default": "geometry.armor_stand.armor.chestplate"
       },
       "scripts": {
-        "parent_setup": "variable.chest_layer_visible = 0.0;"
+        "parent_setup": "v.chest_layer_visible = 0.0;"
       },
       "render_controllers": [ "controller.render.armor" ]
     }

--- a/attachables/golden_leggings.armor_stand.json
+++ b/attachables/golden_leggings.armor_stand.json
@@ -3,7 +3,7 @@
   "minecraft:attachable": {
     "description": {
       "identifier": "minecraft:golden_leggings.armor_stand",
-      "item": { "minecraft:golden_leggings": "query.owner_identifier == 'minecraft:armor_stand'" },
+      "item": { "minecraft:golden_leggings": "q.owner_identifier == 'minecraft:armor_stand'" },
       "materials": {
         "default": "armor",
         "enchanted": "armor_enchanted"
@@ -16,7 +16,7 @@
         "default": "geometry.armor_stand.armor.leggings"
       },
       "scripts": {
-        "parent_setup": "variable.leg_layer_visible = 0.0;"
+        "parent_setup": "v.leg_layer_visible = 0.0;"
       },
       "render_controllers": [ "controller.render.armor" ]
     }

--- a/attachables/iron_chestplate.armor_stand.json
+++ b/attachables/iron_chestplate.armor_stand.json
@@ -3,7 +3,7 @@
   "minecraft:attachable": {
     "description": {
       "identifier": "minecraft:iron_chestplate.armor_stand",
-      "item": { "minecraft:iron_chestplate": "query.owner_identifier == 'minecraft:armor_stand'" },
+      "item": { "minecraft:iron_chestplate": "q.owner_identifier == 'minecraft:armor_stand'" },
       "materials": {
         "default": "armor",
         "enchanted": "armor_enchanted"
@@ -16,7 +16,7 @@
         "default": "geometry.armor_stand.armor.chestplate"
       },
       "scripts": {
-        "parent_setup": "variable.chest_layer_visible = 0.0;"
+        "parent_setup": "v.chest_layer_visible = 0.0;"
       },
       "render_controllers": [ "controller.render.armor" ]
     }

--- a/attachables/iron_leggings.armor_stand.json
+++ b/attachables/iron_leggings.armor_stand.json
@@ -3,7 +3,7 @@
   "minecraft:attachable": {
     "description": {
       "identifier": "minecraft:iron_leggings.armor_stand",
-      "item": { "minecraft:iron_leggings": "query.owner_identifier == 'minecraft:armor_stand'" },
+      "item": { "minecraft:iron_leggings": "q.owner_identifier == 'minecraft:armor_stand'" },
       "materials": {
         "default": "armor",
         "enchanted": "armor_enchanted"
@@ -16,7 +16,7 @@
         "default": "geometry.armor_stand.armor.leggings"
       },
       "scripts": {
-        "parent_setup": "variable.leg_layer_visible = 0.0;"
+        "parent_setup": "v.leg_layer_visible = 0.0;"
       },
       "render_controllers": [ "controller.render.armor" ]
     }

--- a/attachables/leather_chestplate.armor_stand.json
+++ b/attachables/leather_chestplate.armor_stand.json
@@ -3,7 +3,7 @@
   "minecraft:attachable": {
     "description": {
       "identifier": "minecraft:leather_chestplate.armor_stand",
-      "item": { "minecraft:leather_chestplate": "query.owner_identifier == 'minecraft:armor_stand'" },
+      "item": { "minecraft:leather_chestplate": "q.owner_identifier == 'minecraft:armor_stand'" },
       "materials": {
         "default": "armor_leather",
         "enchanted": "armor_leather_enchanted"
@@ -16,7 +16,7 @@
         "default": "geometry.armor_stand.armor.chestplate"
       },
       "scripts": {
-        "parent_setup": "variable.chest_layer_visible = 0.0;"
+        "parent_setup": "v.chest_layer_visible = 0.0;"
       },
       "render_controllers": [ "controller.render.armor" ]
     }

--- a/attachables/leather_leggings.armor_stand.json
+++ b/attachables/leather_leggings.armor_stand.json
@@ -3,7 +3,7 @@
   "minecraft:attachable": {
     "description": {
       "identifier": "minecraft:leather_leggings.armor_stand",
-      "item": { "minecraft:leather_leggings": "query.owner_identifier == 'minecraft:armor_stand'" },
+      "item": { "minecraft:leather_leggings": "q.owner_identifier == 'minecraft:armor_stand'" },
       "materials": {
         "default": "armor_leather",
         "enchanted": "armor_leather_enchanted"
@@ -16,7 +16,7 @@
         "default": "geometry.armor_stand.armor.leggings"
       },
       "scripts": {
-        "parent_setup": "variable.leg_layer_visible = 0.0;"
+        "parent_setup": "v.leg_layer_visible = 0.0;"
       },
       "render_controllers": [ "controller.render.armor" ]
     }

--- a/attachables/netherite_chestplate.armor_stand.json
+++ b/attachables/netherite_chestplate.armor_stand.json
@@ -3,7 +3,7 @@
   "minecraft:attachable": {
     "description": {
       "identifier": "minecraft:netherite_chestplate.armor_stand",
-      "item": { "minecraft:netherite_chestplate": "query.owner_identifier == 'minecraft:armor_stand'" },
+      "item": { "minecraft:netherite_chestplate": "q.owner_identifier == 'minecraft:armor_stand'" },
       "materials": {
         "default": "armor",
         "enchanted": "armor_enchanted"
@@ -16,7 +16,7 @@
         "default": "geometry.armor_stand.armor.chestplate"
       },
       "scripts": {
-        "parent_setup": "variable.chest_layer_visible = 0.0;"
+        "parent_setup": "v.chest_layer_visible = 0.0;"
       },
       "render_controllers": [ "controller.render.armor" ]
     }

--- a/attachables/netherite_leggings.armor_stand.json
+++ b/attachables/netherite_leggings.armor_stand.json
@@ -3,7 +3,7 @@
   "minecraft:attachable": {
     "description": {
       "identifier": "minecraft:netherite_leggings.armor_stand",
-      "item": { "minecraft:netherite_leggings": "query.owner_identifier == 'minecraft:armor_stand'" },
+      "item": { "minecraft:netherite_leggings": "q.owner_identifier == 'minecraft:armor_stand'" },
       "materials": {
         "default": "armor",
         "enchanted": "armor_enchanted"
@@ -16,7 +16,7 @@
         "default": "geometry.armor_stand.armor.leggings"
       },
       "scripts": {
-        "parent_setup": "variable.leg_layer_visible = 0.0;"
+        "parent_setup": "v.leg_layer_visible = 0.0;"
       },
       "render_controllers": [ "controller.render.armor" ]
     }

--- a/entity/armor_stand.entity.json
+++ b/entity/armor_stand.entity.json
@@ -31,13 +31,13 @@
       },
       "scripts": {
         "initialize": [
-          "variable.armor_stand.pose_index = 0;",
-          "variable.armor_stand.hurt_time = 0;"
+          "v.armor_stand.pose_index = 0;",
+          "v.armor_stand.hurt_time = 0;"
         ],
         "animate": [
-          {"controller.pose": "!query.is_bribed"},
-          {"controller.wiggling": "!query.is_bribed"},
-          {"geyser_pose": "query.is_bribed"}
+          {"controller.pose": "!q.is_bribed"},
+          {"controller.wiggling": "!q.is_bribed"},
+          {"geyser_pose": "q.is_bribed"}
         ]
       },
       "geometry": {

--- a/entity/iron_golem.entity.json
+++ b/entity/iron_golem.entity.json
@@ -3,7 +3,7 @@
   "minecraft:client_entity": {
     "description": {
       "identifier": "minecraft:iron_golem",
-      "materials": { "default": "tropicalfish" },
+      "materials": { "default": "custom_iron_golem" },
       "textures": {
         "crackiness_none": "textures/entity/iron_golem/iron_golem_crackiness_none",
         "crackiness_low": "textures/entity/iron_golem/iron_golem_crackiness_low",

--- a/entity/iron_golem.entity.json
+++ b/entity/iron_golem.entity.json
@@ -27,7 +27,7 @@
       },
       "scripts": {
         "pre_animation": [
-          "variable.modified_tcos0 = Math.clamp(((Math.cos(query.modified_distance_moved * 13.5) * Math.min(query.modified_move_speed, 0.6) / variable.gliding_speed_value) * 25.0), -12.5, 12.5);"
+          "v.modified_tcos0 = Math.clamp(((Math.cos(q.modified_distance_moved * 13.5) * Math.min(q.modified_move_speed, 0.6) / v.gliding_speed_value) * 25.0), -12.5, 12.5);"
         ],
         "animate": [
           "look_at_target",

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
         "description": "Geyser Vanilla Assets",
         "name": "Geyser Vanilla Assets",
         "uuid": "5d8f8e98-7a2a-11eb-9439-0242ac130002",
-        "version": [1, 0, 69],
+        "version": [1, 0, 70],
         "min_engine_version": [ 1, 16, 0 ]
     },
     "modules": [
@@ -12,7 +12,7 @@
             "description": "Geyser Vanilla Assets",
             "type": "resources",
             "uuid": "72e9b0ca-7a2a-11eb-9439-0242ac130002",
-            "version": [1, 0, 69]
+            "version": [1, 0, 70]
         }
     ]
 }

--- a/materials/entity.material
+++ b/materials/entity.material
@@ -1,0 +1,24 @@
+{
+  "materials": {
+    "version": "1.0.0",
+    "entity_multitexture_multiplicative_custom_overlay:entity": {
+      "+states": [ "DisableCulling" ],
+      "+samplerStates": [
+        {
+          "samplerIndex": 0,
+          "textureWrap": "Clamp"
+        },
+        {
+          "samplerIndex": 1,
+          "textureWrap": "Clamp"
+        }
+      ],
+      "+defines": [
+        "ALPHA_TEST",
+        "USE_OVERLAY",
+        "MULTIPLICATIVE_TINT"
+      ]
+    },
+    "custom_iron_golem:entity_multitexture_multiplicative_custom_overlay": {}
+  }
+}

--- a/render_controllers/armor_stand.render_controllers.json
+++ b/render_controllers/armor_stand.render_controllers.json
@@ -5,9 +5,9 @@
       "geometry": "geometry.default",
       "part_visibility": [
         { "*": true },
-        { "geyser_leftarm": "!(query.is_angry)" },
-        { "geyser_rightarm": "!(query.is_angry)" },
-        { "geyser_baseplate": "!(query.is_admiring)" }
+        { "geyser_leftarm": "!(q.is_angry)" },
+        { "geyser_rightarm": "!(q.is_angry)" },
+        { "geyser_baseplate": "!(q.is_admiring)" }
       ],
       "materials": [ { "*": "Material.default" } ],
       "textures": [ "texture.default" ],


### PR DESCRIPTION
This PR:
- Fixes the iron golem server side by defining a custom material that allows for texture overlay but is not reliant on color
- Adds documentation regarding materials parenting and definitions
- Updates all variable and query references to conform to short syntax for increased readability (query -> q & variable -> v)

A compressed zip file is attached below for testing purposes. The extension must manually be changed to mcpack.
[geyser.zip](https://github.com/Camotoy/GeyserOptionalPack/files/6082047/geyser.zip)

